### PR TITLE
Configurable modifiers to activate snapping

### DIFF
--- a/application.js
+++ b/application.js
@@ -65,6 +65,21 @@ function getFocusedDisplay() {
     return focusWindow.get_monitor();
 }
 
+function mapModifierSettingToModifierType(modifierSetting) {
+    switch(modifierSetting) {
+        case 'CTRL':
+            return [Clutter.ModifierType.CONTROL_MASK];
+        case 'ALT':
+            return [Clutter.ModifierType.MOD1_MASK, Clutter.ModifierType.MOD5_MASK];
+        case 'SUPER':
+            return [Clutter.ModifierType.SUPER_MASK, Clutter.ModifierType.MOD4_MASK];
+        case 'SHIFT':
+            return [Clutter.ModifierType.SHIFT_MASK];
+        default:            
+            return [];
+    }
+}
+
 // The application class is only constructed once and is the main entry 
 // of the extension.
 class Application {
@@ -166,7 +181,7 @@ class Application {
     }
 
     #enableHotkey() {
-        this.#disableHotkey();
+        this.#disableHotkey();        
         Main.keybindingManager.addHotKey('fancytiles', this.#settings.settingsData.hotkey.value, this.#toggleEditor.bind(this));
     }
 
@@ -258,7 +273,8 @@ class Application {
                 const layout = this.#readOrCreateLayoutForDisplay(displayIdx, LayoutOf2x2);
                 // reload styling
                 this.#loadThemeColors();
-                this.#windowSnapper = new WindowSnapper(displayIdx, layout, window);
+                const enableSnappingModifiers = mapModifierSettingToModifierType(this.#settings.settingsData.enableSnappingModifiers.value);                
+                this.#windowSnapper = new WindowSnapper(displayIdx, layout, window, enableSnappingModifiers);
             }
             return Clutter.EVENT_PROPAGATE;
         });

--- a/node_tree.js
+++ b/node_tree.js
@@ -737,13 +737,15 @@ class PreviewSplitOperation extends LayoutOperation {
 // the user can drag and snap a window into place
 class SnappingOperation extends LayoutOperation {
     showRegions = false;
+    #enableSnappingModifiers;
 
-    constructor(tree) {
+    constructor(tree, enableSnappingModifiers) {
         super(tree);
+        this.#enableSnappingModifiers = enableSnappingModifiers;
     }
 
     onMotion(x, y, state) {
-        var snappingEnabled = (state & Clutter.ModifierType.CONTROL_MASK);
+        var snappingEnabled = this.#enableSnappingModifiers.length == 0 || this.#enableSnappingModifiers.some((e) => (state & e));
 
         if (!snappingEnabled) {
             return this.cancel();

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -1,7 +1,19 @@
 {
- "hotkey": {
-    "type" : "keybinding",
-    "default" : "<Super>g",
-    "description" : "Global Hotkey to open the Fancy Tiles layout editor"
- }
+  "hotkey": {
+    "type": "keybinding",
+    "default": "<Super>g",
+    "description": "Global Hotkey to open the Fancy Tiles layout editor"
+  },
+  "enableSnappingModifiers": {
+    "type": "combobox",
+    "description": "Key modifier required to activate snapping",
+    "default": "CTRL",
+    "options": {
+      "(none)": "",
+      "CTRL": "CTRL",
+      "ALT": "ALT",
+      "SUPER": "SUPER",
+      "SHIFT": "SHIFT"
+    }
+  }
 }

--- a/window-snapper.js
+++ b/window-snapper.js
@@ -9,9 +9,9 @@ const { SnappingOperation } = require('./node_tree');
 
 // the WindowSnapper is used to snap a window to the given layout
 // when the user is dragging a window to a new position and it 
-// holds the <CTRL> key down the layout region where the mouse is
+// holds any of the #enableSnappingModifiers keys down the layout region where the mouse is
 // hovering over will be highlighted. when the user ends the dragging
-// whilst holding the <CTRL> key down the window will be snapped
+// whilst holding any of the #enableSnappingModifiers keys down the window will be snapped
 // to the layout region.
 class WindowSnapper {
     // UI actor
@@ -27,14 +27,20 @@ class WindowSnapper {
     // the snapping operation
     #snappingOperation;
 
+    // the modifier key to enable snapping
+    #enableSnappingModifiers;
+
     #signals = new SignalManager.SignalManager(null);
 
-    constructor(displayIdx, layout, window) {
+    constructor(displayIdx, layout, window, enableSnappingModifiers) {
         // the layout to use for the snapping operation
         this.#layout = layout;
 
         // the window that is being dragged and needs to be snapped
         this.#window = window;
+
+        // the modifier key to enable snapping
+        this.#enableSnappingModifiers = enableSnappingModifiers;
 
         // get the size of the display
         let workArea = getUsableScreenArea(displayIdx);
@@ -59,7 +65,7 @@ class WindowSnapper {
 
         // ensure the layout is correct for the snap area
         this.#layout.calculateRects(workArea.x, workArea.y, workArea.width, workArea.height);
-        this.#snappingOperation = new SnappingOperation(this.#layout);
+        this.#snappingOperation = new SnappingOperation(this.#layout, this.#enableSnappingModifiers);
 
         this.#signals.connect(this.#window, 'position-changed', this.#onWindowMoved.bind(this));
     }


### PR DESCRIPTION
The settings dialog has been expanded with a setting to configure the modifier key required to active the snapping mode when dragging windows.

When the user configures _no_ modifier, then the snapping mode is always activated when a user starts dragging windows.