### PR TITLE
Window can be snapped to any region on any monitor

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,9 +5,9 @@
     "uuid": "fancytiles@basgeertsema",
     "name": "Fancy Tiles",
     "description": "Snap your windows to a flexible layout",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "multiversion": false,
     "url": "https://github.com/basgeertsema/fancytiles",
     "author": "Bas Geertsema",
-    "last-edited": 1744615144
+    "last-edited": 1751367688
 }


### PR DESCRIPTION
When dragging a window, the window can now snap into any region of any monitor. It is no longer bound to the monitor where the dragging was initiated. Just drag a window to another monitor and the regions will appear on that monitor.