### PR TITLE
Add snapping to multiple grid areas

### DIFF
--- a/application.js
+++ b/application.js
@@ -269,16 +269,17 @@ class Application {
     #connectWindowGrabs() {
         // start snapping when the user starts moving a window
         this.#signals.connect(global.display, 'grab-op-begin', (display, screen, window, op) => {
-            if (op === Meta.GrabOp.MOVING && window.window_type === Meta.WindowType.NORMAL) {                                
+            if (op === Meta.GrabOp.MOVING && window.window_type === Meta.WindowType.NORMAL) {
                 // reload styling
                 this.#loadThemeColors();
                 const enableSnappingModifiers = mapModifierSettingToModifierType(this.#settings.settingsData.enableSnappingModifiers.value);
-                
+                const enableMultiSnappingModifiers = mapModifierSettingToModifierType(this.#settings.settingsData.enableMultiSnappingModifiers.value);
+
                 // Create WindowSnapper for each monitor
                 const nMonitors = global.display.get_n_monitors();
                 for (let i = 0; i < nMonitors; i++) {
                     const layout = this.#readOrCreateLayoutForDisplay(i, LayoutOf2x2);
-                    const snapper = new WindowSnapper(i, layout, window, enableSnappingModifiers);
+                    const snapper = new WindowSnapper(i, layout, window, enableSnappingModifiers, enableMultiSnappingModifiers);
                     this.#windowSnappers.push(snapper);
                 }
             }

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -15,5 +15,17 @@
       "SUPER": "SUPER",
       "SHIFT": "SHIFT"
     }
+  },
+  "enableMultiSnappingModifiers": {
+    "type": "combobox",
+    "description": "Key modifier required to activate snapping to multiple arias",
+    "default": "",
+    "options": {
+      "(disabled)": "",
+      "CTRL": "CTRL",
+      "ALT": "ALT",
+      "SUPER": "SUPER",
+      "SHIFT": "SHIFT"
+    }
   }
 }

--- a/window-snapper.js
+++ b/window-snapper.js
@@ -30,9 +30,12 @@ class WindowSnapper {
     // the modifier key to enable snapping
     #enableSnappingModifiers;
 
+    // the modifier key to enable snapping to multiple areas
+    #enableMultiSnappingModifiers;
+
     #signals = new SignalManager.SignalManager(null);
 
-    constructor(displayIdx, layout, window, enableSnappingModifiers) {
+    constructor(displayIdx, layout, window, enableSnappingModifiers, enableMultiSnappingModifiers) {
         // the layout to use for the snapping operation
         this.#layout = layout;
 
@@ -41,6 +44,9 @@ class WindowSnapper {
 
         // the modifier key to enable snapping
         this.#enableSnappingModifiers = enableSnappingModifiers;
+
+        // the modifier key to enable snapping to multiple areas
+        this.#enableMultiSnappingModifiers = enableMultiSnappingModifiers;
 
         // get the size of the display
         let workArea = getUsableScreenArea(displayIdx);
@@ -65,7 +71,7 @@ class WindowSnapper {
 
         // ensure the layout is correct for the snap area
         this.#layout.calculateRects(workArea.x, workArea.y, workArea.width, workArea.height);
-        this.#snappingOperation = new SnappingOperation(this.#layout, this.#enableSnappingModifiers);
+        this.#snappingOperation = new SnappingOperation(this.#layout, this.#enableSnappingModifiers, this.#enableMultiSnappingModifiers);
 
         this.#signals.connect(this.#window, 'position-changed', this.#onWindowMoved.bind(this));
     }


### PR DESCRIPTION
I added one more setting for modifier key. By setting it, we can snap to the multiple areas instead of only one. Basically, you select the first area, press an additional modifier key, and drag to the other areas which the window should fill.

I'm not happy with the name `enableMultiSnapping` and description and I can change it if requested. 