### PR TITLE
A brighter divider color for more contrast

### DIFF
--- a/application.js
+++ b/application.js
@@ -152,10 +152,10 @@ class Application {
         let borderColor = stylingActor.get_theme_node().get_border_color(St.Side.TOP);
         if (borderColor) {
             this.#colors.border = {
-                r: borderColor.red / 255,
-                g: borderColor.green / 255,
-                b: borderColor.blue / 255,
-                a: borderColor.alpha / 255
+                r: borderColor.red / 128,
+                g: borderColor.green / 128,
+                b: borderColor.blue / 128,
+                a: borderColor.alpha / 128
             };
         }
 


### PR DESCRIPTION
As mentioned in #15 , with very dark themes the color user for dividers and borders did not have enough contrast. This change makes the border and divider color more bright which should give enough contrast for both light and dark themes.