### PR TITLE
Merging of adjacent regions before snapping

### DIFF
--- a/application.js
+++ b/application.js
@@ -75,12 +75,12 @@ function mapModifierSettingToModifierType(modifierSetting) {
             return [Clutter.ModifierType.SUPER_MASK, Clutter.ModifierType.MOD4_MASK];
         case 'SHIFT':
             return [Clutter.ModifierType.SHIFT_MASK];
-        default:            
+        default:
             return [];
     }
 }
 
-// The application class is only constructed once and is the main entry 
+// The application class is only constructed once and is the main entry
 // of the extension.
 class Application {
     // the active grid editor
@@ -132,7 +132,7 @@ class Application {
     }
 
     #loadThemeColors() {
-        // hidden element to fetch the styling    
+        // hidden element to fetch the styling
         let stylingActor = new St.DrawingArea({
             style_class: 'tile-preview tile-hud',
             visible: false
@@ -182,7 +182,7 @@ class Application {
     }
 
     #enableHotkey() {
-        this.#disableHotkey();        
+        this.#disableHotkey();
         Main.keybindingManager.addHotKey('fancytiles', this.#settings.settingsData.hotkey.value, this.#toggleEditor.bind(this));
     }
 
@@ -303,4 +303,4 @@ class Application {
     }
 }
 
-module.exports = { Application, LayoutOf2x2 }; 
+module.exports = { Application, LayoutOf2x2 };

--- a/application.js
+++ b/application.js
@@ -269,16 +269,17 @@ class Application {
     #connectWindowGrabs() {
         // start snapping when the user starts moving a window
         this.#signals.connect(global.display, 'grab-op-begin', (display, screen, window, op) => {
-            if (op === Meta.GrabOp.MOVING && window.window_type === Meta.WindowType.NORMAL) {                                
+            if (op === Meta.GrabOp.MOVING && window.window_type === Meta.WindowType.NORMAL) {
                 // reload styling
                 this.#loadThemeColors();
                 const enableSnappingModifiers = mapModifierSettingToModifierType(this.#settings.settingsData.enableSnappingModifiers.value);
-                
+                const enableMultiSnappingModifiers = mapModifierSettingToModifierType(this.#settings.settingsData.enableMultiSnappingModifiers.value);
+
                 // Create WindowSnapper for each monitor
                 const nMonitors = global.display.get_n_monitors();
                 for (let i = 0; i < nMonitors; i++) {
                     const layout = this.#readOrCreateLayoutForDisplay(i, LayoutOf2x2);
-                    const snapper = new WindowSnapper(i, layout, window, enableSnappingModifiers);
+                    const snapper = new WindowSnapper(i, layout, window, enableSnappingModifiers, enableMultiSnappingModifiers);
                     this.#windowSnappers.push(snapper);
                 }
             }

--- a/application.js
+++ b/application.js
@@ -274,12 +274,13 @@ class Application {
                 this.#loadThemeColors();
                 const enableSnappingModifiers = mapModifierSettingToModifierType(this.#settings.settingsData.enableSnappingModifiers.value);
                 const enableMultiSnappingModifiers = mapModifierSettingToModifierType(this.#settings.settingsData.enableMultiSnappingModifiers.value);
+                const enableMergeAdjacentOnHover = this.#settings.settingsData.mergeAdjacentOnHover.value;
 
                 // Create WindowSnapper for each monitor
                 const nMonitors = global.display.get_n_monitors();
                 for (let i = 0; i < nMonitors; i++) {
                     const layout = this.#readOrCreateLayoutForDisplay(i, LayoutOf2x2);
-                    const snapper = new WindowSnapper(i, layout, window, enableSnappingModifiers, enableMultiSnappingModifiers);
+                    const snapper = new WindowSnapper(i, layout, window, enableSnappingModifiers, enableMultiSnappingModifiers, enableMergeAdjacentOnHover);
                     this.#windowSnappers.push(snapper);
                 }
             }

--- a/node_tree.js
+++ b/node_tree.js
@@ -757,11 +757,13 @@ class SnappingOperation extends LayoutOperation {
     showRegions = false;
     #enableSnappingModifiers;
     #enableMultiSnappingModifiers;
-
-    constructor(tree, enableSnappingModifiers, enableMultiSnappingModifiers) {
+    #enableAdjacentMerging;
+    
+    constructor(tree, enableSnappingModifiers, enableMultiSnappingModifiers, enableAdjacentMerging) {
         super(tree);
         this.#enableSnappingModifiers = enableSnappingModifiers;
         this.#enableMultiSnappingModifiers = enableMultiSnappingModifiers;
+        this.#enableAdjacentMerging = enableAdjacentMerging;
     }
 
     onMotion(x, y, state) {

--- a/node_tree.js
+++ b/node_tree.js
@@ -1,33 +1,33 @@
 // A layout is a tree data structure that represents the layout of snapping regions
 // on a display. Each node in the tree represents a region.
-// The internal nodes represent a partitioning (either row or column oriented) and 
+// The internal nodes represent a partitioning (either row or column oriented) and
 // the leaf nodes represent the region for a single window to snap into.
 //
 // The internal nodes, that partition the cell into multiple rows or columns,
 // can contain two or more child nodes. These child nodes can either be
 // another internal node or a leaf node.
-// 
-// Each node holds a percentage value that represents the bottom edge (y-value) or 
+//
+// Each node holds a percentage value that represents the bottom edge (y-value) or
 // right edge (x-value) of the cell as a fraction of the display width (dw) or display height (dh)
-// The percentages are NOT a fraction of the width or height of the parent node. Percentages are 
-// used instead of absolute pixel values to allow the same layout to be used on displays with 
+// The percentages are NOT a fraction of the width or height of the parent node. Percentages are
+// used instead of absolute pixel values to allow the same layout to be used on displays with
 // different resolutions.
 //
-// NEGATIVE percentages are defined as going along the y-axis (row partitioning) and 
+// NEGATIVE percentages are defined as going along the y-axis (row partitioning) and
 // POSITIVE percentages are defined as going along the x-axis (column partitioning).
-// Another perspective on this is that the x axis is positive to the right and the 
-// y axis is negative downwards. By having this convention, we can don´t have to store 
+// Another perspective on this is that the x axis is positive to the right and the
+// y axis is negative downwards. By having this convention, we can don´t have to store
 // the partition type in the node.
 //
-// For example, for a cell that has row partitioning, a value of -0.25 means that the 
+// For example, for a cell that has row partitioning, a value of -0.25 means that the
 // y-coordinate, the bottom edge of the cell, is 25% of the display height (0.25dh). For a cell that
-// has column partitioning, a value of 0.45 means that the x-coordinate, the right edge 
+// has column partitioning, a value of 0.45 means that the x-coordinate, the right edge
 // of the cell, is 45% of the screen width (0.45dw). Percentages are floating point numbers.
 //
 // The LAST child of an internal node does not have a percentage value as the right edge or
 // bottom edge is defined by the parent node. I.e. it fills the remaining space.
 //
-// The calculateRects method calculates the rectangles for all the nodes in the tree in 
+// The calculateRects method calculates the rectangles for all the nodes in the tree in
 // absolute screen coordinates.
 //
 
@@ -47,7 +47,7 @@ const LastNodeYPercentageJson = -99999;
 
 // A node in the tree layout structure
 class LayoutNode {
-    // percentage of screen width (positive) or height (negative). 
+    // percentage of screen width (positive) or height (negative).
     // Always INFINITY or NEGATIVE INFINITY for the last child.
     percentage;
 
@@ -68,7 +68,7 @@ class LayoutNode {
     // isResizing indicates if the divider belonging to this node is being moved by the user
     isResizing = false;
 
-    // isPreview indicates that this node is part of a preview split    
+    // isPreview indicates that this node is part of a preview split
     isPreview = false;
 
     // isHighlighted indicates that this node is visually highlighted
@@ -109,7 +109,7 @@ class LayoutNode {
         return clone;
     }
 
-    // revert the node to the state of the snapshotRootNode, often used 
+    // revert the node to the state of the snapshotRootNode, often used
     // on the root node to revert the whole layout to a previous state
     revert(snapshotRootNode) {
         this.percentage = snapshotRootNode.percentage;
@@ -250,8 +250,8 @@ class LayoutNode {
 
     // validate the calculated rectangles for the node and its descendants
     validateRects() {
-        // we constrain the mnimum size to a reasonable 100 pixels 
-        // as smaller is likely not what the user wants 
+        // we constrain the mnimum size to a reasonable 100 pixels
+        // as smaller is likely not what the user wants
         if (this.rect.width <= 100 || this.rect.height <= 100) {
             return false;
         }
@@ -283,8 +283,8 @@ class LayoutNode {
 
         child.parent = this;
 
-        // insert the child at the correct position/index 
-        // to maintain the sorted invariant        
+        // insert the child at the correct position/index
+        // to maintain the sorted invariant
         this.children.splice(
             this.children.findIndex(c => Math.abs(c.percentage) > Math.abs(child.percentage)),
             0,
@@ -376,28 +376,6 @@ class LayoutNode {
 
         // Return inside nodes with highest priority, then nearby nodes
         return insideNodes.length > 0 ? [...insideNodes, ...nearbyNodes] : nearbyNodes;
-    }
-
-    // check if two nodes are adjacent (share an edge)
-    areNodesAdjacent(node1, node2) {
-        if (!node1 || !node2) return false;    
-
-        // Check horizontal adjacency (left/right)
-        let horizontalOverlap = !(node1.rect.y + node1.rect.height <= node2.rect.y ||
-                                  node2.rect.y + node2.rect.height <= node1.rect.y);
-
-        let node1RightOfNode2 = Math.abs(node1.rect.x - (node2.rect.x + node2.rect.width));
-        let node2RightOfNode1 = Math.abs(node2.rect.x - (node1.rect.x + node1.rect.width));
-
-        // Check vertical adjacency (top/bottom)
-        let verticalOverlap = !(node1.rect.x + node1.rect.width <= node2.rect.x ||
-                                node2.rect.x + node2.rect.width <= node1.rect.x);
-
-        let node1BelowNode2 = Math.abs(node1.rect.y - (node2.rect.y + node2.rect.height));
-        let node2BelowNode1 = Math.abs(node2.rect.y - (node1.rect.y + node1.rect.height));
-
-        return (horizontalOverlap && (node1RightOfNode2 || node2RightOfNode1)) ||
-               (verticalOverlap && (node1BelowNode2 || node2BelowNode1));
     }
 
     // get the rectangle of the divider for this node, useful for grabbing and moving the divider
@@ -703,7 +681,7 @@ class PreviewSplitOperation extends LayoutOperation {
     }
 
     _handlePreview(x, y, state) {
-        // Check for preview partition creation    
+        // Check for preview partition creation
         let ctrlPressed = (state & Clutter.ModifierType.CONTROL_MASK) !== 0;
         let shiftPressed = (state & Clutter.ModifierType.SHIFT_MASK) !== 0;
         let previewModeEnabled = ctrlPressed || shiftPressed;
@@ -726,9 +704,9 @@ class PreviewSplitOperation extends LayoutOperation {
             result = OperationResult.handledAndRedraw();
         }
 
-        // start a new preview if 
-        // 1) there is no preview yet and 
-        // 2) we are moving over a cell and 
+        // start a new preview if
+        // 1) there is no preview yet and
+        // 2) we are moving over a cell and
         // 3) ctrl or shift is pressed (preview mode)
         if (!previewNode
             && node && node.isLeaf()
@@ -751,7 +729,7 @@ class PreviewSplitOperation extends LayoutOperation {
 
         // move around the divider on a resizing (preview)node
         if (previewNode) {
-            // calculate the percentages  
+            // calculate the percentages
             let percentage = previewNode.isColumn() ? ((x - this.tree.rect.x) / this.tree.rect.width) : -((y - this.tree.rect.y) / this.tree.rect.height);
 
             let oldPercentage = previewNode.percentage;
@@ -773,7 +751,7 @@ class PreviewSplitOperation extends LayoutOperation {
     }
 
     _startPreview(splittingNode, percentage) {
-        // Split a leaf node into two nodes, with the given percentage as starting point           
+        // Split a leaf node into two nodes, with the given percentage as starting point
         let previewNode = new LayoutNode(percentage);
         previewNode.isPreview = true;
         previewNode.isHighlighted = true;
@@ -814,13 +792,13 @@ class SnappingOperation extends LayoutOperation {
     #enableMultiSnappingModifiers;
     #enableAdjacentMerging;
     #mergingRadius;
-    
+
     constructor(tree, enableSnappingModifiers, enableMultiSnappingModifiers, enableAdjacentMerging, mergingRadius) {
         super(tree);
         this.#enableSnappingModifiers = enableSnappingModifiers;
         this.#enableMultiSnappingModifiers = enableMultiSnappingModifiers;
         this.#enableAdjacentMerging = enableAdjacentMerging;
-        this.#mergingRadius = mergingRadius;        
+        this.#mergingRadius = mergingRadius;
     }
 
     onMotion(x, y, state) {
@@ -828,7 +806,7 @@ class SnappingOperation extends LayoutOperation {
         if (!snappingEnabled) {
             return this.cancel();
         }
-        
+
         let node = this.tree.findNodeAtPosition(x, y);
         if(!node){
             return OperationResult.notHandled();
@@ -836,23 +814,23 @@ class SnappingOperation extends LayoutOperation {
 
         // first check for multi-region snapping using the key modifier
         const multiSnapEnabled = this.#enableMultiSnappingModifiers.some((e) => (state & e));
-        
+
         // if multi-region snapping is enabled the regions that are snapping destinations are retained
         // this allows the user to expand the snapping region by moving around.
         // if multi-region snapping is not enabled we first clear all snapping destinations
-        if(!multiSnapEnabled) {        
+        if(!multiSnapEnabled) {
             this.tree.forSelfAndDescendants(n => {
                 n.isSnappingDestination = false;
                 n.isHighlighted = false;
             });
-            this.tree.insetNode = null;            
+            this.tree.insetNode = null;
         }
 
         // the regions in a radius around the mouse position will become snapping destinations
-        const regionSelectionRadius = this.#enableAdjacentMerging ? this.#mergingRadius : 0;        
-        
+        const regionSelectionRadius = this.#enableAdjacentMerging ? this.#mergingRadius : 0;
+
         // find the regions with the radius and set them as snapping destinations
-        let nearbyNodes = this.tree.findNodesNearPosition(x, y, regionSelectionRadius);                
+        let nearbyNodes = this.tree.findNodesNearPosition(x, y, regionSelectionRadius);
         nearbyNodes.forEach(node => {
             node.isSnappingDestination = true;
             node.isHighlighted = true;
@@ -864,16 +842,16 @@ class SnappingOperation extends LayoutOperation {
             const multisnapRect = this.multisnapRect();
             if(!this.tree.insetNode){
                 this.tree.insetNode = new LayoutNode(0);
-                this.tree.insetNode.parent = this.tree;            
+                this.tree.insetNode.parent = this.tree;
                 this.tree.insetNode.margin = node.margin;
                 this.tree.insetNode.isSnappingDestination = true;
                 this.tree.insetNode.isHighlighted = true;
-            }            
+            }
             this.tree.insetNode.rect = multisnapRect;
         } else {
             this.tree.insetNode = null;
         }
-            
+
         this.showRegions = true;
         return OperationResult.handledAndRedraw();
     }
@@ -908,7 +886,7 @@ class SnappingOperation extends LayoutOperation {
             });
     }
 
-    currentSnapToRect() {        
+    currentSnapToRect() {
         if(this.tree.insetNode){
             return this.tree.insetNode.snapRect();
         }
@@ -1012,4 +990,4 @@ module.exports = {
     SnappingOperation,
     MarginsOperation,
     PresetShortcutOperation
-}; 
+};

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -27,5 +27,11 @@
       "SUPER": "SUPER",
       "SHIFT": "SHIFT"
     }
+  },
+  "mergeAdjacentOnHover": {
+    "type": "switch",
+    "description": "Merge adjacent regions when hovering over the shared border",
+    "tooltip": "When enabled, adjacent regions will be merged when hovering over the shared border. When disabled, adjacent regions will not be merged.",
+    "default": true
   }
 }

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -15,5 +15,17 @@
       "SUPER": "SUPER",
       "SHIFT": "SHIFT"
     }
+  },
+  "enableMultiSnappingModifiers": {
+    "type": "combobox",
+    "description": "Key modifier required to activate snapping to multiple arias",
+    "default": "",
+    "options": {
+      "(disabled)": "",
+      "CTRL": "CTRL",
+      "ALT": "ALT",
+      "SUPER": "SUPER",
+      "SHIFT": "SHIFT"
+    }
   }
 }

--- a/shapes.js
+++ b/shapes.js
@@ -1,0 +1,234 @@
+// helper utilities to build polygon paths used for drawing
+
+// quantize floating point coordinates so we can safely use them as map keys
+const COORD_PRECISION = 1e6;
+
+function toKeyCoord(value) {
+    return Math.round(value * COORD_PRECISION);
+}
+
+// collect unique finite values while preserving numeric ordering
+function uniqueSorted(values) {
+    const seen = new Set();
+    const unique = [];
+    for (const value of values) {
+        if (!Number.isFinite(value)) continue;
+        const key = toKeyCoord(value);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        unique.push(value);
+    }
+    unique.sort((a, b) => a - b);
+    return unique;
+}
+
+function pointKey(point) {
+    return `${toKeyCoord(point.x)}:${toKeyCoord(point.y)}`;
+}
+
+function edgeKey(x1, y1, x2, y2) {
+    const ax = toKeyCoord(x1);
+    const ay = toKeyCoord(y1);
+    const bx = toKeyCoord(x2);
+    const by = toKeyCoord(y2);
+    const minX = Math.min(ax, bx);
+    const minY = Math.min(ay, by);
+    const maxX = Math.max(ax, bx);
+    const maxY = Math.max(ay, by);
+    return `${minX}:${minY}:${maxX}:${maxY}`;
+}
+
+function orientedEdgeKey(edge) {
+    return `${pointKey(edge.start)}->${pointKey(edge.end)}`;
+}
+
+function polygonArea(points) {
+    if (!points || points.length < 3) return 0;
+    let area = 0;
+    for (let i = 0; i < points.length; i++) {
+        const { x: x1, y: y1 } = points[i];
+        const { x: x2, y: y2 } = points[(i + 1) % points.length];
+        area += x1 * y2 - x2 * y1;
+    }
+    return area * 0.5;
+}
+
+// return the axis-aligned portion shared by both rectangles (if any)
+function computeIntersection(rect, excludedRect) {
+    if (!rect || !excludedRect) return null;
+
+    const left = Math.max(rect.x, excludedRect.x);
+    const right = Math.min(rect.x + rect.width, excludedRect.x + excludedRect.width);
+    const top = Math.max(rect.y, excludedRect.y);
+    const bottom = Math.min(rect.y + rect.height, excludedRect.y + excludedRect.height);
+
+    if (right <= left || bottom <= top) return null;
+
+    return {
+        x: left,
+        y: top,
+        width: right - left,
+        height: bottom - top
+    };
+}
+
+// create a clockwise polygon for rect minus the overlapping part of excludedRect
+function buildDifferencePath(rect, excludedRect) {
+    if (!rect) return [];
+
+    const rectLeft = rect.x;
+    const rectRight = rect.x + rect.width;
+    const rectTop = rect.y;
+    const rectBottom = rect.y + rect.height;
+
+    if (!(rectRight > rectLeft) || !(rectBottom > rectTop)) {
+        return [];
+    }
+
+    const intersection = computeIntersection(rect, excludedRect);
+
+    if (!intersection) {
+        return [
+            { x: rectLeft, y: rectTop },
+            { x: rectRight, y: rectTop },
+            { x: rectRight, y: rectBottom },
+            { x: rectLeft, y: rectBottom }
+        ];
+    }
+
+    // slice the area into a minimal grid defined by unique X/Y breakpoints
+    const xs = uniqueSorted([rectLeft, rectRight, intersection.x, intersection.x + intersection.width]);
+    const ys = uniqueSorted([rectTop, rectBottom, intersection.y, intersection.y + intersection.height]);
+
+    const cells = [];
+
+    for (let xi = 0; xi < xs.length - 1; xi++) {
+        const x0 = xs[xi];
+        const x1 = xs[xi + 1];
+        if (x1 <= x0) continue;
+        const cx = (x0 + x1) / 2;
+
+        for (let yi = 0; yi < ys.length - 1; yi++) {
+            const y0 = ys[yi];
+            const y1 = ys[yi + 1];
+            if (y1 <= y0) continue;
+            const cy = (y0 + y1) / 2;
+
+            const insideRect = cx >= rectLeft && cx <= rectRight && cy >= rectTop && cy <= rectBottom;
+            const insideIntersection = cx >= intersection.x && cx <= intersection.x + intersection.width &&
+                cy >= intersection.y && cy <= intersection.y + intersection.height;
+
+            // retain cells that belong to rect but not the overlapped region
+            if (insideRect && !insideIntersection) {
+                cells.push({ x0, x1, y0, y1 });
+            }
+        }
+    }
+
+    if (cells.length === 0) {
+        return [];
+    }
+
+    const edgeMap = new Map();
+
+    // add rectangle edges, removing pairs that are shared between adjacent cells
+    function addEdge(x1, y1, x2, y2) {
+        if (Math.abs(x1 - x2) < 1e-7 && Math.abs(y1 - y2) < 1e-7) {
+            return;
+        }
+        const key = edgeKey(x1, y1, x2, y2);
+        if (edgeMap.has(key)) {
+            edgeMap.delete(key);
+        } else {
+            edgeMap.set(key, {
+                start: { x: x1, y: y1 },
+                end: { x: x2, y: y2 }
+            });
+        }
+    }
+
+    for (const cell of cells) {
+        addEdge(cell.x0, cell.y0, cell.x1, cell.y0);
+        addEdge(cell.x1, cell.y0, cell.x1, cell.y1);
+        addEdge(cell.x1, cell.y1, cell.x0, cell.y1);
+        addEdge(cell.x0, cell.y1, cell.x0, cell.y0);
+    }
+
+    const edges = Array.from(edgeMap.values());
+    if (edges.length === 0) {
+        return [];
+    }
+
+    const edgesByStart = new Map();
+    // bucket edges by start vertex so we can follow connected boundary segments
+    for (const edge of edges) {
+        const startKey = pointKey(edge.start);
+        if (!edgesByStart.has(startKey)) {
+            edgesByStart.set(startKey, []);
+        }
+        edgesByStart.get(startKey).push(edge);
+    }
+
+    const visited = new Set();
+    let bestLoop = null;
+    let bestArea = -Infinity;
+
+    // walk every possible loop and keep the one with the largest area (outer boundary)
+    for (const edge of edges) {
+        const firstKey = orientedEdgeKey(edge);
+        if (visited.has(firstKey)) continue;
+
+        const loop = [];
+        let currentEdge = edge;
+        const loopStartKey = pointKey(edge.start);
+
+        while (true) {
+            const currentKey = orientedEdgeKey(currentEdge);
+            if (visited.has(currentKey)) break;
+            visited.add(currentKey);
+            loop.push({ x: currentEdge.start.x, y: currentEdge.start.y });
+
+            const nextKey = pointKey(currentEdge.end);
+            if (nextKey === loopStartKey) {
+                break;
+            }
+
+            const candidates = edgesByStart.get(nextKey);
+            if (!candidates || candidates.length === 0) {
+                loop.length = 0;
+                break;
+            }
+
+            let nextEdge = null;
+            for (const candidate of candidates) {
+                const candidateKey = orientedEdgeKey(candidate);
+                if (!visited.has(candidateKey)) {
+                    nextEdge = candidate;
+                    break;
+                }
+            }
+
+            if (!nextEdge) {
+                loop.length = 0;
+                break;
+            }
+
+            currentEdge = nextEdge;
+        }
+
+        if (loop.length > 0) {
+            const area = Math.abs(polygonArea(loop));
+            if (area > bestArea) {
+                bestArea = area;
+                bestLoop = loop;
+            }
+        }
+    }
+
+    return bestLoop || [];
+}
+
+module.exports = {
+    buildDifferencePath,
+    polygonArea
+};

--- a/window-snapper.js
+++ b/window-snapper.js
@@ -30,9 +30,12 @@ class WindowSnapper {
     // the modifier key to enable snapping
     #enableSnappingModifiers;
 
+    // the modifier key to enable snapping to multiple areas
+    #enableMultiSnappingModifiers;
+
     #signals = new SignalManager.SignalManager(null);
 
-    constructor(displayIdx, layout, window, enableSnappingModifiers) {
+    constructor(displayIdx, layout, window, enableSnappingModifiers, enableMultiSnappingModifiers) {
         // the layout to use for the snapping operation
         this.#layout = layout;
 
@@ -41,6 +44,9 @@ class WindowSnapper {
 
         // the modifier key to enable snapping
         this.#enableSnappingModifiers = enableSnappingModifiers;
+
+        // the modifier key to enable snapping to multiple areas
+        this.#enableMultiSnappingModifiers = enableMultiSnappingModifiers;
 
         // get the size of the display
         let workArea = getUsableScreenArea(displayIdx);
@@ -65,7 +71,7 @@ class WindowSnapper {
 
         // ensure the layout is correct for the snap area
         this.#layout.calculateRects(workArea.x, workArea.y, workArea.width, workArea.height);
-        this.#snappingOperation = new SnappingOperation(this.#layout, this.#enableSnappingModifiers);
+        this.#snappingOperation = new SnappingOperation(this.#layout, this.#enableSnappingModifiers, this.#enableMultiSnappingModifiers);
 
         this.#signals.connect(this.#window, 'position-changed', this.#onWindowMoved.bind(this));
     }

--- a/window-snapper.js
+++ b/window-snapper.js
@@ -33,9 +33,12 @@ class WindowSnapper {
     // the modifier key to enable snapping to multiple areas
     #enableMultiSnappingModifiers;
 
+    // whether to merge adjacent regions when hovering over the shared border
+    #enableAdjacentMerging;
+
     #signals = new SignalManager.SignalManager(null);
 
-    constructor(displayIdx, layout, window, enableSnappingModifiers, enableMultiSnappingModifiers) {
+    constructor(displayIdx, layout, window, enableSnappingModifiers, enableMultiSnappingModifiers, enableAdjacentMerging) {
         // the layout to use for the snapping operation
         this.#layout = layout;
 
@@ -47,6 +50,11 @@ class WindowSnapper {
 
         // the modifier key to enable snapping to multiple areas
         this.#enableMultiSnappingModifiers = enableMultiSnappingModifiers;
+
+        // whether to merge adjacent regions when hovering over the shared border
+        this.#enableAdjacentMerging = enableAdjacentMerging;
+
+        console.log('enableAdjacentMerging', enableAdjacentMerging);
 
         // get the size of the display
         let workArea = getUsableScreenArea(displayIdx);


### PR DESCRIPTION
Regions are now by default merged into a single larger region when the mouse hovers over the edge between two adjacent regions. Furthermore, when holding the `<ALT>` key modifier, the region can further be expanded by hovering the mouse over more regions. The single large region is previewed live before snapping, so the user can see exactly where the window will end up.

Both of the features can be switched off in the settings menu. They have been enabled by default as it seems to work quite intuitive, and it is still very easy to snap a window into just a single region.

This PR merges the work in #17 and #19 by @carrot-sticks and @Icestou .