### PR TITLE
Support for guide lines in grid editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open Cinnamon Extensions, click on the Fancy Tiles extension and click the '+' b
 
 ## Quick start
 
-After enabling the extension, press `<SUPER>+G` to open the layout editor. It will start with a 2x2 grid layout. Click and drag the dividers (the lines between regions) to resize the regions. If you want to split a region, press `<SHIFT>` or `<CTRL>` while hovering over the region to split the region horizontally or vertically. Use the `right mouse button` to remove dividers. Use `<Page Up>` and `<Page Down>` to increase or decrease the spacing between the regions.
+After enabling the extension, press `<SUPER>+G` to open the layout editor. It will start with a 2x2 grid layout. Click and drag the dividers (the lines between regions) to resize the regions. If you want to split a region, press `<SHIFT>` or `<CTRL>` while hovering over the region to split the region horizontally or vertically. The dotted guide lines are located at 1/3, 1/2 and 2/3 along the axis. Use the `right mouse button` to remove dividers. Use `<Page Up>` and `<Page Down>` to increase or decrease the spacing between the regions.
 
 After you have crafted your desired layout, exit the editor using `<SUPER>+G` or `<ESC>`.
 

--- a/application.js
+++ b/application.js
@@ -235,12 +235,15 @@ class Application {
             this.#loadPresets();
         }
 
+        const showGuideLines = this.#settings.settingsData.showGuideLines.value;
+
         this.#gridEditor = new GridEditor(
             displayIdx,
             layout,
             this.#colors,
             this.#closeEditor.bind(this),
-            this.#presets
+            this.#presets,
+            showGuideLines
         );
     }
 

--- a/grid-editor.js
+++ b/grid-editor.js
@@ -37,18 +37,22 @@ class GridEditor {
     // the callback to call when the editor is closed
     #onClose;
 
+    // whether to show guide lines when splitting
+    #showGuideLines;
+
     // operations on the layout tree
     #marginsOperation;
     #previewOperation;
     #resizeOperation;
     #presetShortcutOperation;
 
-    constructor(displayIdx, layoutTree, colors, onClose, presets) {
+    constructor(displayIdx, layoutTree, colors, onClose, presets, showGuideLines) {
         this.#displayIdx = displayIdx;
         this.#layoutTree = layoutTree;
         this.#colors = colors;
         this.#onClose = onClose;
         this.#presets = presets;
+        this.#showGuideLines = showGuideLines;
 
         // get the working area to occupy as a grid editor   
         // and resize the layout to fit the work area
@@ -80,7 +84,7 @@ class GridEditor {
         this.#presetTextColor = this.#loadPresetDialog.get_theme_node().get_foreground_color();
 
         // the operations to do when in the grid editor
-        this.#previewOperation = new PreviewSplitOperation(this.#layoutTree, this.#workArea.width, this.#workArea.height);
+        this.#previewOperation = new PreviewSplitOperation(this.#layoutTree, this.#workArea.width, this.#workArea.height, this.#showGuideLines);
         this.#resizeOperation = new ResizeOperation(this.#layoutTree, this.#workArea.width, this.#workArea.height);
         this.#marginsOperation = new MarginsOperation(this.#layoutTree);
         this.#presetShortcutOperation = new PresetShortcutOperation(this.#layoutTree, this.#presets, this.#usePreset.bind(this));
@@ -360,7 +364,7 @@ class GridEditor {
 
         // Draw split guide lines at 1/3, 1/2, and 2/3 of the region being split
         const previewNode = tree.findNode(n => n.isPreview);
-        if (previewNode && previewNode.parent) {
+        if (this.#showGuideLines && previewNode && previewNode.parent) {
             const parentRect = previewNode.splitGuideRect || previewNode.parent.rect;
             const isColumn = previewNode.isColumn();
 

--- a/grid-editor.js
+++ b/grid-editor.js
@@ -358,6 +358,41 @@ class GridEditor {
         // Draw the layout
         drawLayout(cr, tree, { x: actorX, y: actorY }, this.#colors);
 
+        // Draw split guide lines at 1/3, 1/2, and 2/3 of the region being split
+        const previewNode = tree.findNode(n => n.isPreview);
+        if (previewNode && previewNode.parent) {
+            const parentRect = previewNode.splitGuideRect || previewNode.parent.rect;
+            const isColumn = previewNode.isColumn();
+
+            cr.save();
+            const bc = this.#colors.border;
+            cr.setSourceRGBA(bc.r, bc.g, bc.b, 0.35);
+            cr.setLineWidth(1.5);
+            cr.setDash([3, 6], 0);
+            cr.setLineCap(Cairo.LineCap.ROUND);
+
+            const margin = previewNode.margin;
+            const px = parentRect.x - actorX;
+            const py = parentRect.y - actorY;
+            const pw = parentRect.width;
+            const ph = parentRect.height;
+
+            for (const frac of [1/3, 0.5, 2/3]) {
+                if (isColumn) {
+                    const lineX = px + pw * frac;
+                    cr.moveTo(lineX, py + margin);
+                    cr.lineTo(lineX, py + ph - margin);
+                } else {
+                    const lineY = py + ph * frac;
+                    cr.moveTo(px + margin, lineY);
+                    cr.lineTo(px + pw - margin, lineY);
+                }
+                cr.stroke();
+            }
+
+            cr.restore();
+        }
+
         cr.$dispose();
     }
 

--- a/node_tree.js
+++ b/node_tree.js
@@ -638,9 +638,11 @@ class ResizeOperation extends LayoutOperation {
 // the user can preview a split in the layout
 class PreviewSplitOperation extends LayoutOperation {
     prePreviewSnapshot = null;
+    #showGuideLines;
 
-    constructor(tree) {
+    constructor(tree, screenWidth, screenHeight, showGuideLines) {
         super(tree);
+        this.#showGuideLines = showGuideLines;
     }
 
     onMotion(x, y, state) {
@@ -733,19 +735,21 @@ class PreviewSplitOperation extends LayoutOperation {
             let percentage = previewNode.isColumn() ? ((x - this.tree.rect.x) / this.tree.rect.width) : -((y - this.tree.rect.y) / this.tree.rect.height);
 
             // Snap to 1/3, 1/2, or 2/3 of the region being split (within 3% of the region)
-            const regionRect = previewNode.splitGuideRect || previewNode.parent.rect;
-            const isColumn = previewNode.isColumn();
-            const screenSize = isColumn ? this.tree.rect.width : this.tree.rect.height;
-            const screenOffset = isColumn ? this.tree.rect.x : this.tree.rect.y;
-            const regionStart = isColumn ? regionRect.x : regionRect.y;
-            const regionSize = isColumn ? regionRect.width : regionRect.height;
-            const snapPoints = [1/3, 1/2, 2/3];
-            for (const snap of snapPoints) {
-                const snapScreenPos = regionStart + regionSize * snap;
-                const snapPercentage = ((snapScreenPos - screenOffset) / screenSize) * (isColumn ? 1 : -1);
-                if (Math.abs(percentage - snapPercentage) <= 0.03 * (regionSize / screenSize)) {
-                    percentage = snapPercentage;
-                    break;
+            if (this.#showGuideLines) {
+                const regionRect = previewNode.splitGuideRect || previewNode.parent.rect;
+                const isColumn = previewNode.isColumn();
+                const screenSize = isColumn ? this.tree.rect.width : this.tree.rect.height;
+                const screenOffset = isColumn ? this.tree.rect.x : this.tree.rect.y;
+                const regionStart = isColumn ? regionRect.x : regionRect.y;
+                const regionSize = isColumn ? regionRect.width : regionRect.height;
+                const snapPoints = [1/3, 1/2, 2/3];
+                for (const snap of snapPoints) {
+                    const snapScreenPos = regionStart + regionSize * snap;
+                    const snapPercentage = ((snapScreenPos - screenOffset) / screenSize) * (isColumn ? 1 : -1);
+                    if (Math.abs(percentage - snapPercentage) <= 0.03 * (regionSize / screenSize)) {
+                        percentage = snapPercentage;
+                        break;
+                    }
                 }
             }
 

--- a/node_tree.js
+++ b/node_tree.js
@@ -211,7 +211,7 @@ class LayoutNode {
             let axis = child.axis();
 
             // calculate the position of the edge along the axis
-            let posOnAxis = displayOnAxis[axis] + Math.round(Math.abs(screenLength[axis] * child.percentage) / 10) * 10;
+            let posOnAxis = displayOnAxis[axis] + Math.round(Math.abs(screenLength[axis] * child.percentage));
 
             if (axis === AxisX) {
                 // child is a column node
@@ -732,6 +732,23 @@ class PreviewSplitOperation extends LayoutOperation {
             // calculate the percentages
             let percentage = previewNode.isColumn() ? ((x - this.tree.rect.x) / this.tree.rect.width) : -((y - this.tree.rect.y) / this.tree.rect.height);
 
+            // Snap to 1/3, 1/2, or 2/3 of the region being split (within 3% of the region)
+            const regionRect = previewNode.splitGuideRect || previewNode.parent.rect;
+            const isColumn = previewNode.isColumn();
+            const screenSize = isColumn ? this.tree.rect.width : this.tree.rect.height;
+            const screenOffset = isColumn ? this.tree.rect.x : this.tree.rect.y;
+            const regionStart = isColumn ? regionRect.x : regionRect.y;
+            const regionSize = isColumn ? regionRect.width : regionRect.height;
+            const snapPoints = [1/3, 1/2, 2/3];
+            for (const snap of snapPoints) {
+                const snapScreenPos = regionStart + regionSize * snap;
+                const snapPercentage = ((snapScreenPos - screenOffset) / screenSize) * (isColumn ? 1 : -1);
+                if (Math.abs(percentage - snapPercentage) <= 0.03 * (regionSize / screenSize)) {
+                    percentage = snapPercentage;
+                    break;
+                }
+            }
+
             let oldPercentage = previewNode.percentage;
             previewNode.percentage = percentage;
 
@@ -758,6 +775,9 @@ class PreviewSplitOperation extends LayoutOperation {
         previewNode.margin = splittingNode.margin;
 
         if (previewNode.axis() === splittingNode.axis() && splittingNode.parent) {
+            // Store the original splitting node's rect before rects are recalculated,
+            // so the guide lines in the grid editor can reference the correct region.
+            previewNode.splitGuideRect = { x: splittingNode.rect.x, y: splittingNode.rect.y, width: splittingNode.rect.width, height: splittingNode.rect.height };
             // request the parent to insert a new node
             splittingNode.parent.insertChild(previewNode);
             splittingNode.isHighlighted = true;

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -42,6 +42,12 @@
     "tooltip": "When enabled, all regions with a radius of the mouse cursor are merged into a single region into which the window will snap",
     "default": true
   },
+  "showGuideLines": {
+    "type": "switch",
+    "description": "Show guide lines in the grid editor",
+    "tooltip": "When enabled, guide lines at 1/3, 1/2 and 2/3 are shown in the grid editor when splitting a region",
+    "default": true
+  },
   "mergingRadius": {
     "type": "scale",
     "description": "Radius around the mouse cursor used for merging",


### PR DESCRIPTION
Dotted guide lines are now visible in the grid editor and are located at 1/3, 1/2 and 2/3 along the axis.  This allows for an easy and intuitive way to achieve common ratios between regions.

If the user wants to split a region into 4 quarters it can easily be done by splitting into 1/2 two times. 

If the users wants to split at 1/4 and 3/4 it can split into 1/2 two times and then remove one of the dividers.